### PR TITLE
fix: all sample projects failed on build

### DIFF
--- a/samples/Sample1/OpenSleigh.Samples.Sample1.Console/OpenSleigh.Samples.Sample1.Console.csproj
+++ b/samples/Sample1/OpenSleigh.Samples.Sample1.Console/OpenSleigh.Samples.Sample1.Console.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
   </ItemGroup>

--- a/samples/Sample2/OpenSleigh.Samples.Sample2.Worker/OpenSleigh.Samples.Sample2.Worker.csproj
+++ b/samples/Sample2/OpenSleigh.Samples.Sample2.Worker/OpenSleigh.Samples.Sample2.Worker.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
   </ItemGroup>

--- a/samples/Sample3/OpenSleigh.Samples.Sample3.Worker/OpenSleigh.Samples.Sample3.Worker.csproj
+++ b/samples/Sample3/OpenSleigh.Samples.Sample3.Worker/OpenSleigh.Samples.Sample3.Worker.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
   </ItemGroup>

--- a/samples/Sample4/OpenSleigh.Samples.Sample4.InventoryService/OpenSleigh.Samples.Sample4.InventoryService.csproj
+++ b/samples/Sample4/OpenSleigh.Samples.Sample4.InventoryService/OpenSleigh.Samples.Sample4.InventoryService.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
   </ItemGroup>

--- a/samples/Sample4/OpenSleigh.Samples.Sample4.NotificationsService/OpenSleigh.Samples.Sample4.NotificationsService.csproj
+++ b/samples/Sample4/OpenSleigh.Samples.Sample4.NotificationsService/OpenSleigh.Samples.Sample4.NotificationsService.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
   </ItemGroup>

--- a/samples/Sample4/OpenSleigh.Samples.Sample4.Orchestrator/OpenSleigh.Samples.Sample4.Orchestrator.csproj
+++ b/samples/Sample4/OpenSleigh.Samples.Sample4.Orchestrator/OpenSleigh.Samples.Sample4.Orchestrator.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
   </ItemGroup>

--- a/samples/Sample4/OpenSleigh.Samples.Sample4.PaymentService/OpenSleigh.Samples.Sample4.PaymentService.csproj
+++ b/samples/Sample4/OpenSleigh.Samples.Sample4.PaymentService/OpenSleigh.Samples.Sample4.PaymentService.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
   </ItemGroup>

--- a/samples/Sample4/OpenSleigh.Samples.Sample4.ShippingService/OpenSleigh.Samples.Sample4.ShippingService.csproj
+++ b/samples/Sample4/OpenSleigh.Samples.Sample4.ShippingService/OpenSleigh.Samples.Sample4.ShippingService.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
   </ItemGroup>

--- a/samples/Sample5/OpenSleigh.Samples.Sample5.Console/OpenSleigh.Samples.Sample5.Console.csproj
+++ b/samples/Sample5/OpenSleigh.Samples.Sample5.Console/OpenSleigh.Samples.Sample5.Console.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
   </ItemGroup>

--- a/samples/Sample6/OpenSleigh.Samples.Sample6.Console/OpenSleigh.Samples.Sample6.Console.csproj
+++ b/samples/Sample6/OpenSleigh.Samples.Sample6.Console/OpenSleigh.Samples.Sample6.Console.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
   </ItemGroup>

--- a/samples/Sample7/OpenSleigh.Samples.Sample7.Console/OpenSleigh.Samples.Sample7.Console.csproj
+++ b/samples/Sample7/OpenSleigh.Samples.Sample7.Console/OpenSleigh.Samples.Sample7.Console.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
   </ItemGroup>

--- a/samples/Sample9/OpenSleigh.Samples.Sample9.Worker/OpenSleigh.Samples.Sample9.Worker.csproj
+++ b/samples/Sample9/OpenSleigh.Samples.Sample9.Worker/OpenSleigh.Samples.Sample9.Worker.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
   </ItemGroup>


### PR DESCRIPTION
all sample projects failed on build due to an incompatible version of Microsoft.Extensions.DependencyInjection (>=5.0.2) in OpenSleigh.Core