### PR TITLE
Add net8.0 support

### DIFF
--- a/Versions.props
+++ b/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageVersion>3.0.4</PackageVersion>
     <CSharpLanguageVersion>12</CSharpLanguageVersion>
-    <TargetFrameworkVersion>net9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>net8.0;net9.0</TargetFrameworkVersion>
     <RepositoryUrl>https://github.com/mizrael/OpenSleigh</RepositoryUrl>
     <PackageProjectUrl>https://opensleigh.gitbook.io/</PackageProjectUrl>
   </PropertyGroup>

--- a/samples/OpenSleigh.Samples.Blazor/OpenSleigh.Samples.Blazor/OpenSleigh.Samples.Blazor.csproj
+++ b/samples/OpenSleigh.Samples.Blazor/OpenSleigh.Samples.Blazor/OpenSleigh.Samples.Blazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.API/Controllers/OrdersController.cs
+++ b/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.API/Controllers/OrdersController.cs
@@ -21,7 +21,11 @@ public class OrdersController : ControllerBase
     [HttpPost]
     public async Task<IActionResult> PostOrder(CancellationToken cancellationToken = default)
     {
+#if NET9_0_OR_GREATER
         var message = new SaveOrder(OrderId: Guid.CreateVersion7());
+#else
+        var message = new SaveOrder(OrderId: Guid.NewGuid());
+#endif
         
         await _bus.PublishAsync(message, cancellationToken);
 

--- a/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.API/OpenSleigh.Samples.ECommerce.API.csproj
+++ b/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.API/OpenSleigh.Samples.ECommerce.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-   <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'OpenSleigh.Samples.Sample2.API' " />

--- a/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.Common/OpenSleigh.Samples.ECommerce.Common.csproj
+++ b/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.Common/OpenSleigh.Samples.ECommerce.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.InventoryService/OpenSleigh.Samples.ECommerce.InventoryService.csproj
+++ b/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.InventoryService/OpenSleigh.Samples.ECommerce.InventoryService.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-   <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.NotificationsService/OpenSleigh.Samples.ECommerce.NotificationsService.csproj
+++ b/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.NotificationsService/OpenSleigh.Samples.ECommerce.NotificationsService.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-   <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.Orchestrator/OpenSleigh.Samples.ECommerce.Orchestrator.csproj
+++ b/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.Orchestrator/OpenSleigh.Samples.ECommerce.Orchestrator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-   <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.PaymentService/OpenSleigh.Samples.ECommerce.PaymentService.csproj
+++ b/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.PaymentService/OpenSleigh.Samples.ECommerce.PaymentService.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-   <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.ShippingService/OpenSleigh.Samples.ECommerce.ShippingService.csproj
+++ b/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.ShippingService/OpenSleigh.Samples.ECommerce.ShippingService.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-   <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.Sample1/OpenSleigh.Samples.Sample1.csproj
+++ b/samples/OpenSleigh.Samples.Sample1/OpenSleigh.Samples.Sample1.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/OpenSleigh.Samples.Sample2/OpenSleigh.Samples.Sample2.API/OpenSleigh.Samples.Sample2.API.csproj
+++ b/samples/OpenSleigh.Samples.Sample2/OpenSleigh.Samples.Sample2.API/OpenSleigh.Samples.Sample2.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.Sample2/OpenSleigh.Samples.Sample2.Common/OpenSleigh.Samples.Sample2.Common.csproj
+++ b/samples/OpenSleigh.Samples.Sample2/OpenSleigh.Samples.Sample2.Common/OpenSleigh.Samples.Sample2.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.Sample2/OpenSleigh.Samples.Sample2.Worker/OpenSleigh.Samples.Sample2.Worker.csproj
+++ b/samples/OpenSleigh.Samples.Sample2/OpenSleigh.Samples.Sample2.Worker/OpenSleigh.Samples.Sample2.Worker.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenSleigh.InMemory/OpenSleigh.InMemory.csproj
+++ b/src/OpenSleigh.InMemory/OpenSleigh.InMemory.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+		<TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/OpenSleigh.Persistence.Mongo/OpenSleigh.Persistence.Mongo.csproj
+++ b/src/OpenSleigh.Persistence.Mongo/OpenSleigh.Persistence.Mongo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+		<TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/OpenSleigh.Persistence.PostgreSQL/OpenSleigh.Persistence.PostgreSQL.csproj
+++ b/src/OpenSleigh.Persistence.PostgreSQL/OpenSleigh.Persistence.PostgreSQL.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+		<TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/OpenSleigh.Persistence.SQL/OpenSleigh.Persistence.SQL.csproj
+++ b/src/OpenSleigh.Persistence.SQL/OpenSleigh.Persistence.SQL.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+		<TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/OpenSleigh.Persistence.SQL/SqlSagaStateRepository.cs
+++ b/src/OpenSleigh.Persistence.SQL/SqlSagaStateRepository.cs
@@ -118,7 +118,11 @@ public class SqlSagaStateRepository : ISagaStateRepository
         }
 
         entity.LockTime = DateTimeOffset.UtcNow;
+#if NET9_0_OR_GREATER
         entity.LockId = Guid.CreateVersion7().ToString();
+#else
+        entity.LockId = Guid.NewGuid().ToString();
+#endif
 
         await _dbContext.SaveChangesAsync(cancellationToken)
                         .ConfigureAwait(false);

--- a/src/OpenSleigh.Persistence.SQLServer/OpenSleigh.Persistence.SQLServer.csproj
+++ b/src/OpenSleigh.Persistence.SQLServer/OpenSleigh.Persistence.SQLServer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+		<TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/OpenSleigh.Transport.Kafka/OpenSleigh.Transport.Kafka.csproj
+++ b/src/OpenSleigh.Transport.Kafka/OpenSleigh.Transport.Kafka.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+		<TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/OpenSleigh.Transport.RabbitMQ/OpenSleigh.Transport.RabbitMQ.csproj
+++ b/src/OpenSleigh.Transport.RabbitMQ/OpenSleigh.Transport.RabbitMQ.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+		<TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/OpenSleigh/NoOpSagaInstance.cs
+++ b/src/OpenSleigh/NoOpSagaInstance.cs
@@ -33,7 +33,11 @@ internal class NoOpSagaInstance : ISagaInstance
         Descriptor = descriptor,
         TriggerMessageId = messageContext.MessageId,
         CorrelationId = messageContext.CorrelationId,
+#if NET9_0_OR_GREATER
         InstanceId = Guid.CreateVersion7().ToString()
+#else
+        InstanceId = Guid.NewGuid().ToString()
+#endif
     };
 
     public bool CanProcess<TM>(IMessageContext<TM> messageContext) where TM : IMessage

--- a/src/OpenSleigh/OpenSleigh.csproj
+++ b/src/OpenSleigh/OpenSleigh.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+		<TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/OpenSleigh/Outbox/MessageEnvelope.cs
+++ b/src/OpenSleigh/Outbox/MessageEnvelope.cs
@@ -77,11 +77,21 @@ public class MessageEnvelope
     {
         ArgumentNullException.ThrowIfNull(message);
 
-        var correlationId = message is IHasCorrelationId cm ?
-            cm.CorrelationId : Guid.CreateVersion7().ToString("N");
+        var correlationId = message is IHasCorrelationId cm
+            ? cm.CorrelationId
+#if NET9_0_OR_GREATER
+            : Guid.CreateVersion7().ToString("N");
+#else
+            : Guid.NewGuid().ToString("N");
+#endif
 
-        var messageId = message is IIdempotentMessage im ?
-            im.GetIdempotencyKey() : Guid.CreateVersion7().ToString("N");
+        var messageId = message is IIdempotentMessage im
+            ? im.GetIdempotencyKey()
+#if NET9_0_OR_GREATER
+            : Guid.CreateVersion7().ToString("N");
+#else
+            : Guid.NewGuid().ToString("N");
+#endif
 
         return new MessageEnvelope()
         {
@@ -103,8 +113,13 @@ public class MessageEnvelope
         var correlationId = message is IHasCorrelationId cm ?
             cm.CorrelationId : sagaInstance.CorrelationId;
 
-        var messageId = message is IIdempotentMessage im ?
-            im.GetIdempotencyKey() : Guid.CreateVersion7().ToString("N");
+        var messageId = message is IIdempotentMessage im
+            ? im.GetIdempotencyKey()
+#if NET9_0_OR_GREATER
+            : Guid.CreateVersion7().ToString("N");
+#else
+            : Guid.NewGuid().ToString("N");
+#endif
 
         return new MessageEnvelope()
         {

--- a/src/OpenSleigh/SagaInstanceFactory.cs
+++ b/src/OpenSleigh/SagaInstanceFactory.cs
@@ -12,7 +12,11 @@ public class SagaInstanceFactory : ISagaInstanceFactory
 
         if (descriptor.SagaStateType is null)
             return new SagaInstance(
+#if NET9_0_OR_GREATER
                 instanceId: Guid.CreateVersion7().ToString(),
+#else
+                instanceId: Guid.NewGuid().ToString(),
+#endif
                 triggerMessageId: messageContext.MessageId,
                 correlationId: messageContext.CorrelationId,
                 descriptor: descriptor);
@@ -27,7 +31,11 @@ public class SagaInstanceFactory : ISagaInstanceFactory
     private static ISagaInstance Create<TS, TM>(TS state, IMessageContext<TM> messageContext, SagaDescriptor descriptor)
         where TM : IMessage
         => new SagaInstance<TS>(
+#if NET9_0_OR_GREATER
             instanceId: Guid.CreateVersion7().ToString(),
+#else
+            instanceId: Guid.NewGuid().ToString(),
+#endif
             triggerMessageId: messageContext.MessageId,
             correlationId: messageContext.CorrelationId,
             descriptor,

--- a/src/OpenSleigh/SystemInfo.cs
+++ b/src/OpenSleigh/SystemInfo.cs
@@ -34,7 +34,11 @@ internal record SystemInfo : ISystemInfo
         if (string.IsNullOrWhiteSpace(clientGroup))
             clientGroup = AppDomain.CurrentDomain?.FriendlyName;
         if (string.IsNullOrWhiteSpace(clientId))
+#if NET9_0_OR_GREATER
             clientId = Guid.CreateVersion7().ToString();
+#else
+            clientId = Guid.NewGuid().ToString();
+#endif
 
         return new SystemInfo(clientGroup: clientGroup, clientId: clientId);
     }

--- a/tests/OpenSleigh.E2ETests/IdempotentMessageScenario.cs
+++ b/tests/OpenSleigh.E2ETests/IdempotentMessageScenario.cs
@@ -26,8 +26,13 @@ public abstract class IdempotentMessageScenario : E2ETestsBase
         if (hostsCount > _maxHostsCount)
             return;
 
+#if NET9_0_OR_GREATER
         var requestId = Guid.CreateVersion7().ToString("N");
         var correlationId = Guid.CreateVersion7().ToString("N");
+#else
+        var requestId = Guid.NewGuid().ToString("N");
+        var correlationId = Guid.NewGuid().ToString("N");
+#endif
         var message1 = new IdempotentMessage(requestId, correlationId, 0);
         var message2 = new IdempotentMessage(requestId, correlationId, 1);
 

--- a/tests/OpenSleigh.E2ETests/OpenSleigh.E2ETests.csproj
+++ b/tests/OpenSleigh.E2ETests/OpenSleigh.E2ETests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/OpenSleigh.E2ETests/SQLKafka/SqlKafkaSimpleSagaScenario.cs
+++ b/tests/OpenSleigh.E2ETests/SQLKafka/SqlKafkaSimpleSagaScenario.cs
@@ -17,7 +17,12 @@ public class SqlKafkaSimpleSagaScenario :
     {
         _dbFixture = dbFixture;
         _kafkaFixture = kafkaFixture;
-        _exchangeName = "SQLKafkaSimpleSagaScenario-" + Guid.CreateVersion7().ToString("N");
+        _exchangeName = "SQLKafkaSimpleSagaScenario-" +
+#if NET9_0_OR_GREATER
+            Guid.CreateVersion7().ToString("N");
+#else
+            Guid.NewGuid().ToString("N");
+#endif
     }
 
     protected override void ConfigureTransportAndPersistence(IBusConfigurator cfg)

--- a/tests/OpenSleigh.Persistence.Mongo.Tests/OpenSleigh.Persistence.Mongo.Tests.csproj
+++ b/tests/OpenSleigh.Persistence.Mongo.Tests/OpenSleigh.Persistence.Mongo.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/OpenSleigh.Persistence.SQL.Tests/OpenSleigh.Persistence.SQL.Tests.csproj
+++ b/tests/OpenSleigh.Persistence.SQL.Tests/OpenSleigh.Persistence.SQL.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/OpenSleigh.Tests/OpenSleigh.Tests.csproj
+++ b/tests/OpenSleigh.Tests/OpenSleigh.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/OpenSleigh.Transport.Kafka.Tests/Fixtures/KafkaFixture.cs
+++ b/tests/OpenSleigh.Transport.Kafka.Tests/Fixtures/KafkaFixture.cs
@@ -19,7 +19,11 @@ public class KafkaFixture
     public KafkaConfiguration BuildKafkaConfiguration(string? topicPrefix = null)
     {
         if(string.IsNullOrWhiteSpace(topicPrefix))
+#if NET9_0_OR_GREATER
             topicPrefix = Guid.CreateVersion7().ToString();
+#else
+            topicPrefix = Guid.NewGuid().ToString();
+#endif
         
         return new KafkaConfiguration(_connStr, 
             t => new QueueReferences($"{topicPrefix}.{t.FullName}", $"{topicPrefix}.{t.FullName}.dead"));

--- a/tests/OpenSleigh.Transport.Kafka.Tests/OpenSleigh.Transport.Kafka.Tests.csproj
+++ b/tests/OpenSleigh.Transport.Kafka.Tests/OpenSleigh.Transport.Kafka.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+	<TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/OpenSleigh.Transport.RabbitMQ.Tests/Fixtures/RabbitFixture.cs
+++ b/tests/OpenSleigh.Transport.RabbitMQ.Tests/Fixtures/RabbitFixture.cs
@@ -42,7 +42,11 @@ public class RabbitFixture : IAsyncLifetime
 
     private QueueReferences CreateQueueReference()
     {
+#if NET9_0_OR_GREATER
         var queueName = System.Guid.CreateVersion7().ToString("N");
+#else
+        var queueName = System.Guid.NewGuid().ToString("N");
+#endif
         return new QueueReferences(queueName, queueName, $"{queueName}.dead", $"{queueName}.dead");
     }
 

--- a/tests/OpenSleigh.Transport.RabbitMQ.Tests/Integration/RabbitMessageSubscriberTests.cs
+++ b/tests/OpenSleigh.Transport.RabbitMQ.Tests/Integration/RabbitMessageSubscriberTests.cs
@@ -109,7 +109,11 @@ public class RabbitMessageSubscriberTests : IClassFixture<RabbitFixture>
 
         QueueReferencesCreator queueReferencesCreator = messageType =>
         {
+#if NET9_0_OR_GREATER
             var exchangeName = $"{messageType.Name.ToLower()}-{Guid.CreateVersion7().ToString("N")}";
+#else
+            var exchangeName = $"{messageType.Name.ToLower()}-{Guid.NewGuid().ToString("N")}";
+#endif
             var queueName = $"{exchangeName}.workers";
             var dlExchangeName = exchangeName + ".dead";
             var dlQueueName = $"{dlExchangeName}.workers";
@@ -119,8 +123,13 @@ public class RabbitMessageSubscriberTests : IClassFixture<RabbitFixture>
 
         var sysInfo = NSubstitute.Substitute.For<ISystemInfo>();
         sysInfo.ClientGroup.Returns("test");
+#if NET9_0_OR_GREATER
         sysInfo.ClientId.Returns(Guid.CreateVersion7().ToString("N"));
         sysInfo.Id.Returns(Guid.CreateVersion7().ToString("N"));
+#else
+        sysInfo.ClientId.Returns(Guid.NewGuid().ToString("N"));
+        sysInfo.Id.Returns(Guid.NewGuid().ToString("N"));
+#endif
         services.AddSingleton(sysInfo);
 
         var typeResolver = Substitute.For<ITypeResolver>();

--- a/tests/OpenSleigh.Transport.RabbitMQ.Tests/OpenSleigh.Transport.RabbitMQ.Tests.csproj
+++ b/tests/OpenSleigh.Transport.RabbitMQ.Tests/OpenSleigh.Transport.RabbitMQ.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworkVersion)</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
* Change project files to support multiple frameworks
* Change version prop file to indicate net8.0 and net9.0
* Add NET9_0_OR_GREATER directives around instances of `Guid.CreateVersion7()`, using `Guid.NewGuid()` otherwise

I'm not sure the implications with the build/test/package portions, but having .NET 8 support would be extremely, extremely useful for a project we're working on now where upgrading to .NET 9 is not possible, and using an older version of OpenSleigh is undesirable.