### PR TITLE
Fix E2E test flakiness from multi-host concurrency issues

### DIFF
--- a/src/OpenSleigh.InMemory/InMemorySagaStateRepository.cs
+++ b/src/OpenSleigh.InMemory/InMemorySagaStateRepository.cs
@@ -5,63 +5,62 @@ namespace OpenSleigh.InMemory;
 
 internal class InMemorySagaStateRepository : ISagaStateRepository
 {
-    private readonly ConcurrentDictionary<string, (ISagaInstance  state, string? lockId)> _statesByDescriptor = new();
-    private readonly ConcurrentDictionary<string, (ISagaInstance  state, string? lockId)> _statesById = new();
+    private readonly ConcurrentDictionary<string, (ISagaInstance state, string? lockId)> _statesByDescriptor = new();
+    private readonly ConcurrentDictionary<string, (ISagaInstance state, string? lockId)> _statesById = new();
+    private readonly object _lockSync = new();
 
-    public ValueTask<ISagaInstance ?> FindAsync<TM>(SagaDescriptor descriptor, IMessageContext<TM> messageContext, CancellationToken cancellationToken = default)
+    public ValueTask<ISagaInstance?> FindAsync<TM>(SagaDescriptor descriptor, IMessageContext<TM> messageContext, CancellationToken cancellationToken = default)
         where TM : IMessage
     {
         string key = BuildKey(descriptor, messageContext.CorrelationId);
 
-        ISagaInstance ? state = null;
+        ISagaInstance? state = null;
 
         if (_statesByDescriptor.TryGetValue(key, out var val))
             state = val.state;
 
         return ValueTask.FromResult(state);
-
     }
 
-    public ValueTask<string> LockAsync(ISagaInstance  state, CancellationToken cancellationToken = default)
+    public ValueTask<string> LockAsync(ISagaInstance state, CancellationToken cancellationToken = default)
     {
         string lockId = Guid.NewGuid().ToString();
-        
-        _statesById.AddOrUpdate(state.InstanceId,
-            _ => (state, lockId),
-            (k, v) =>
-            {
-                if (v.lockId is not null)
-                    throw new LockException($"saga '{state.InstanceId}' is already locked");
-                return (state, lockId);
-            });
-
         string key = BuildKey(state.Descriptor, state.CorrelationId);
-        _statesByDescriptor.AddOrUpdate(key,
-           _ => (state, lockId),
-           (k, v) =>
-           {
-               if (v.lockId is not null)
-               {
-                   _statesById.TryRemove(state.InstanceId, out _);
-                   _statesByDescriptor.TryRemove(key, out _);
-                   throw new OptimisticLockException($"saga '{state.InstanceId}' is already locked");
-               }
-               return (state, lockId);
-           });
+
+        lock (_lockSync)
+        {
+            if (_statesById.TryGetValue(state.InstanceId, out var byId) && byId.lockId is not null)
+                throw new LockException($"saga '{state.InstanceId}' is already locked");
+
+            if (_statesByDescriptor.TryGetValue(key, out var byDesc) && byDesc.lockId is not null)
+                throw new OptimisticLockException($"saga '{state.InstanceId}' is already locked");
+
+            _statesById[state.InstanceId] = (state, lockId);
+            _statesByDescriptor[key] = (state, lockId);
+        }
 
         return ValueTask.FromResult(lockId);
     }
 
-    public ValueTask ReleaseAsync(ISagaInstance  state, CancellationToken cancellationToken = default)
+    public ValueTask ReleaseAsync(ISagaInstance state, CancellationToken cancellationToken = default)
     {
         string key = BuildKey(state.Descriptor, state.CorrelationId);
-        _statesByDescriptor.AddOrUpdate(key, _ => (state, null), (_, _) => (state, null));
 
-        _statesById.AddOrUpdate(state.InstanceId, _ => (state, null), (_, _) => (state, null));
+        lock (_lockSync)
+        {
+            if (!string.IsNullOrEmpty(state.LockId)
+                && _statesById.TryGetValue(state.InstanceId, out var entry)
+                && entry.lockId is not null
+                && entry.lockId != state.LockId)
+                throw new LockException($"unable to release saga '{state.InstanceId}' with lock id '{state.LockId}'");
+
+            _statesByDescriptor[key] = (state, null);
+            _statesById[state.InstanceId] = (state, null);
+        }
 
         return ValueTask.CompletedTask;
     }
 
-    private static string BuildKey(SagaDescriptor descriptor, string correlationId) 
-        => $"{correlationId}|{descriptor.SagaType.FullName}|{descriptor.SagaStateType?.FullName ?? string.Empty}";        
+    private static string BuildKey(SagaDescriptor descriptor, string correlationId)
+        => $"{correlationId}|{descriptor.SagaType.FullName}|{descriptor.SagaStateType?.FullName ?? string.Empty}";
 }

--- a/src/OpenSleigh.InMemory/Messaging/InMemorySubscriber.cs
+++ b/src/OpenSleigh.InMemory/Messaging/InMemorySubscriber.cs
@@ -52,16 +52,15 @@ public class InMemorySubscriber : IMessageSubscriber, IDisposable
                     await _messageProcessor.ProcessAsync(outboxMessage, cancellationToken)
                                            .ConfigureAwait(false);
                 }
-                catch (Exception e)
+                catch (Exception e) when (e is not OperationCanceledException)
                 {
                     _logger.LogError(e,
                         "an exception has occurred while processing message '{MessageId}': {Error}",
                         outboxMessage.MessageId,
                         e.Message);
-                    if (e is LockException or OptimisticLockException)
-                        await Task.Delay(100, cancellationToken)
-                            .ContinueWith(_ => _publisher.PublishAsync(outboxMessage, cancellationToken), cancellationToken)
-                            .ConfigureAwait(false);
+                    await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+                    await _publisher.PublishAsync(outboxMessage, cancellationToken)
+                                    .ConfigureAwait(false);
                 }
             }).ToArray();
 

--- a/src/OpenSleigh.Persistence.PostgreSQL/SqlBusConfiguratorExtensions.cs
+++ b/src/OpenSleigh.Persistence.PostgreSQL/SqlBusConfiguratorExtensions.cs
@@ -38,9 +38,10 @@ public static class SqlBusConfiguratorExtensions
         _ => false
     };
 
+    // TODO: this sucks hard
     private static bool IsDuplicateKeyException(InvalidOperationException ex)
     => ex.Source == "Microsoft.EntityFrameworkCore" &&
-            ex.Message.Contains($"The instance of entity type '{nameof(OutboxMessage)}' cannot be tracked because another instance with the key value");
+            ex.Message.Contains("cannot be tracked because another instance with the");
     
     private static bool IsDuplicateKeyException(DbUpdateException ex)
     {

--- a/src/OpenSleigh.Persistence.SQL/Entities/SagaState.cs
+++ b/src/OpenSleigh.Persistence.SQL/Entities/SagaState.cs
@@ -29,6 +29,8 @@ internal class SagaStateEntityTypeConfiguration : IEntityTypeConfiguration<SagaS
         builder.HasIndex(e => new { e.CorrelationId, e.SagaType }).IsUnique();
         builder.HasIndex(e => new { e.CorrelationId, e.SagaType, e.SagaStateType }).IsUnique();
 
+        builder.Property(e => e.LockId).IsConcurrencyToken();
+
         builder.HasMany(e => e.ProcessedMessages)
             .WithOne(e => e.SagaState);
     }

--- a/src/OpenSleigh.Persistence.SQL/SqlSagaStateRepository.cs
+++ b/src/OpenSleigh.Persistence.SQL/SqlSagaStateRepository.cs
@@ -134,6 +134,10 @@ public class SqlSagaStateRepository : ISagaStateRepository
             await _dbContext.SaveChangesAsync(cancellationToken)
                             .ConfigureAwait(false);
         }
+        catch (DbUpdateConcurrencyException)
+        {
+            throw new LockException($"saga state '{state.InstanceId}' is already locked");
+        }
         catch (DbUpdateException)
         {
             entity = await _dbContext.SagaStates

--- a/src/OpenSleigh.Transport.RabbitMQ/IBusConfiguratorExtensions.cs
+++ b/src/OpenSleigh.Transport.RabbitMQ/IBusConfiguratorExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpenSleigh.DependencyInjection;
 using RabbitMQ.Client;
 using System.Diagnostics.CodeAnalysis;
@@ -14,7 +15,7 @@ public static class IBusConfiguratorExtensions
         QueueReferencesCreator? queueReferencesCreator = null)
     {
         if (queueReferencesCreator is null)
-            busConfigurator.Services.AddSingleton(ctx =>
+            busConfigurator.Services.TryAddSingleton(ctx =>
             {
                 var sysInfo = ctx.GetRequiredService<ISystemInfo>();
                 return QueueReferenceFactory.BuildDefaultCreator(sysInfo);

--- a/src/OpenSleigh.Transport.RabbitMQ/IChannelExtensions.cs
+++ b/src/OpenSleigh.Transport.RabbitMQ/IChannelExtensions.cs
@@ -18,22 +18,22 @@ public static class IChannelExtensions
         ArgumentNullException.ThrowIfNull(rabbitCfg);
         ArgumentNullException.ThrowIfNull(channel);
 
-        var exchangeName = queueReferences.ExchangeName;
-        if (_initialized.ContainsKey(exchangeName))
+        var topologyKey = $"{queueReferences.ExchangeName}|{queueReferences.QueueName}";
+        if (_initialized.ContainsKey(topologyKey))
             return;
 
-        var semaphore = _semaphores.GetOrAdd(exchangeName, _ => new SemaphoreSlim(1, 1));
+        var semaphore = _semaphores.GetOrAdd(topologyKey, _ => new SemaphoreSlim(1, 1));
 
         await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            if (_initialized.ContainsKey(exchangeName))
+            if (_initialized.ContainsKey(topologyKey))
                 return;
 
             await EnsureExchangesAsync(queueReferences, channel, rabbitCfg, cancellationToken);
             await EnsureQueuesAsync(queueReferences, channel, rabbitCfg, cancellationToken);
 
-            _initialized.TryAdd(exchangeName, 0);
+            _initialized.TryAdd(topologyKey, 0);
         }
         finally
         {
@@ -122,7 +122,8 @@ public static class IChannelExtensions
         await channel.ExchangeDeleteAsync(queueRef.RetryExchangeName);
         await channel.QueueDeleteAsync(queueRef.RetryQueueName);
 
-        _initialized.TryRemove(queueRef.ExchangeName, out _);
-        _semaphores.TryRemove(queueRef.ExchangeName, out _);
+        var topologyKey = $"{queueRef.ExchangeName}|{queueRef.QueueName}";
+        _initialized.TryRemove(topologyKey, out _);
+        _semaphores.TryRemove(topologyKey, out _);
     }
 }

--- a/src/OpenSleigh/ISagaExecutionService.cs
+++ b/src/OpenSleigh/ISagaExecutionService.cs
@@ -26,4 +26,11 @@ public interface ISagaExecutionService
     ValueTask CommitAsync(
         ISagaInstance context,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// releases the lock on the saga instance without persisting state changes.
+    /// </summary>
+    ValueTask ReleaseAsync(
+        ISagaInstance context,
+        CancellationToken cancellationToken = default);
 }

--- a/src/OpenSleigh/SagaExecutionService.cs
+++ b/src/OpenSleigh/SagaExecutionService.cs
@@ -51,7 +51,7 @@ public class SagaExecutionService : ISagaExecutionService
         return sagaInstance;
     }
 
-    private async Task<ISagaInstance> BeginProcessingCore<TM>(IMessageContext<TM> messageContext, SagaDescriptor descriptor, CancellationToken cancellationToken) 
+    private async Task<ISagaInstance> BeginProcessingCore<TM>(IMessageContext<TM> messageContext, SagaDescriptor descriptor, CancellationToken cancellationToken)
         where TM : IMessage
     {
         var sagaInstance = await ResolveInstanceAsync(messageContext, descriptor, cancellationToken).ConfigureAwait(false);
@@ -62,7 +62,24 @@ public class SagaExecutionService : ISagaExecutionService
         await sagaInstance.LockAsync(_sagaStateRepository, cancellationToken)
                           .ConfigureAwait(false);
 
+        // re-check after lock to close TOCTOU window: another thread may have
+        // processed the same message between the initial check and lock acquisition
+        if (!sagaInstance.CanProcess(messageContext))
+        {
+            await _sagaStateRepository.ReleaseAsync(sagaInstance, cancellationToken)
+                                      .ConfigureAwait(false);
+            return NoOpSagaInstance.Create(messageContext, descriptor);
+        }
+
         return sagaInstance;
+    }
+
+    public ValueTask ReleaseAsync(
+        ISagaInstance context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return _sagaStateRepository.ReleaseAsync(context, cancellationToken);
     }
 
     public async ValueTask CommitAsync(

--- a/src/OpenSleigh/SagaInstance.cs
+++ b/src/OpenSleigh/SagaInstance.cs
@@ -80,7 +80,7 @@ public record SagaInstance : ISagaInstance
         => _outbox.Clear();
 
     public async ValueTask ProcessAsync<TM>(
-        IMessageHandlerManager messageHandlerManager, 
+        IMessageHandlerManager messageHandlerManager,
         IMessageContext<TM> messageContext,
         ISagaExecutionService sagaExecutionService,
         CancellationToken cancellationToken = default) where TM : IMessage
@@ -89,16 +89,36 @@ public record SagaInstance : ISagaInstance
         ArgumentNullException.ThrowIfNull(messageContext);
         ArgumentNullException.ThrowIfNull(sagaExecutionService);
 
-        await messageHandlerManager.ProcessAsync(this, messageContext, cancellationToken)
-                                   .ConfigureAwait(false);
+        try
+        {
+            await messageHandlerManager.ProcessAsync(this, messageContext, cancellationToken)
+                                       .ConfigureAwait(false);
 
-        this.SetAsProcessed(messageContext);
+            this.SetAsProcessed(messageContext);
 
-        await sagaExecutionService.CommitAsync(this, cancellationToken)
-                                  .ConfigureAwait(false);
+            await sagaExecutionService.CommitAsync(this, cancellationToken)
+                                      .ConfigureAwait(false);
 
-        // to be done after Commit, as it will be checked when releasing the state
-        this.LockId = string.Empty;
+            // to be done after Commit, as it will be checked when releasing the state
+            this.LockId = string.Empty;
+        }
+        catch
+        {
+            if (!string.IsNullOrEmpty(this.LockId))
+            {
+                try
+                {
+                    await sagaExecutionService.ReleaseAsync(this, CancellationToken.None)
+                                              .ConfigureAwait(false);
+                }
+                catch
+                {
+                    // best effort: lock will expire via LockMaxDuration for SQL/Mongo
+                }
+                this.LockId = string.Empty;
+            }
+            throw;
+        }
     }
 
     public string TriggerMessageId { get; }

--- a/tests/OpenSleigh.E2ETests/ParallelMultiStartSagaScenario.cs
+++ b/tests/OpenSleigh.E2ETests/ParallelMultiStartSagaScenario.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using OpenSleigh.DependencyInjection;
 using OpenSleigh.Transport;
+using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Text.Json;
@@ -43,7 +44,7 @@ public abstract class ParallelMultiStartSagaScenario : E2ETestsBase
 
         MultiStartSagaState state = null!;
 
-        HashSet<string> instanceIds = [];
+        ConcurrentBag<string> instanceIds = [];
 
         Action<IMessageContext<StartMultiStartSaga>, ISagaInstance<MultiStartSagaState>> onStart = (ctx, inst) =>
         {
@@ -52,7 +53,7 @@ public abstract class ParallelMultiStartSagaScenario : E2ETestsBase
             Assert.False(string.IsNullOrWhiteSpace(ctx.SenderId));
 
             instanceIds.Add(inst.InstanceId);
-            receivedCount++;
+            Interlocked.Increment(ref receivedCount);
             if (ReferenceEquals(last, start))
             {
                 state = inst.State;
@@ -65,7 +66,7 @@ public abstract class ParallelMultiStartSagaScenario : E2ETestsBase
         {
             Console.WriteLine($"Handled AlsoStart message {JsonSerializer.Serialize(ctx.Message, new JsonSerializerOptions { WriteIndented = true })}");
             instanceIds.Add(inst.InstanceId);
-            receivedCount++;
+            Interlocked.Increment(ref receivedCount);
             if (ReferenceEquals(last, alsoStart))
             {
                 state = inst.State;
@@ -93,7 +94,7 @@ public abstract class ParallelMultiStartSagaScenario : E2ETestsBase
         );
 
         Assert.Equal(2, receivedCount);
-        Assert.Single(instanceIds);
+        Assert.Single(instanceIds.Distinct());
 
         // These work correctly for in-memory scenarios because the object is always the same
         // Not having access to the host's container, I'm not sure if there's an appropriate way to get at the

--- a/tests/OpenSleigh.E2ETests/SequentialMultiStartSagaScenario.cs
+++ b/tests/OpenSleigh.E2ETests/SequentialMultiStartSagaScenario.cs
@@ -35,12 +35,12 @@ public abstract class SequentialMultiStartSagaScenario : E2ETestsBase
         using var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10) * hostsCount);
 
         MultiStartSagaState state = null!;
-        var handled = false;
+        var handled = 0;
 
         Action<IMessageContext<StartMultiStartSaga>, ISagaInstance<MultiStartSagaState>> onStart = (_, inst) =>
         {
-            receivedCount++;
-            handled = true;
+            Interlocked.Increment(ref receivedCount);
+            Volatile.Write(ref handled, 1);
             if (ReferenceEquals(last, start))
             {
                 state = inst.State;
@@ -51,8 +51,8 @@ public abstract class SequentialMultiStartSagaScenario : E2ETestsBase
 
         Action<IMessageContext<AlsoStartMultiStartSaga>, ISagaInstance<MultiStartSagaState>> onAlsoStart = (_, inst) =>
         {
-            receivedCount++;
-            handled = true;
+            Interlocked.Increment(ref receivedCount);
+            Volatile.Write(ref handled, 1);
             if (ReferenceEquals(last, alsoStart))
             {
                 state = inst.State;
@@ -71,7 +71,7 @@ public abstract class SequentialMultiStartSagaScenario : E2ETestsBase
             {
                 await bus.PublishAsync(first, tokenSource.Token);
 
-                while (!handled)
+                while (Volatile.Read(ref handled) == 0)
                     await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
 
                 // wait one more second for unlocking

--- a/tests/OpenSleigh.Tests/InMemorySagaStateRepositoryTests.cs
+++ b/tests/OpenSleigh.Tests/InMemorySagaStateRepositoryTests.cs
@@ -53,6 +53,56 @@ public class InMemorySagaStateRepositoryTests
     }
 
     [Fact]
+    public async Task ReleaseAsync_should_throw_when_lock_id_does_not_match()
+    {
+        var repository = new InMemorySagaStateRepository();
+        var descriptor = SagaDescriptor.Create<FakeSaga>();
+        var instance = new SagaInstance(
+            Guid.NewGuid().ToString(),
+            Guid.NewGuid().ToString(),
+            Guid.NewGuid().ToString(),
+            descriptor);
+
+        var sagaStateRepo = Substitute.For<ISagaStateRepository>();
+
+        // Lock via repository to store the lock
+        await repository.LockAsync(instance, CancellationToken.None);
+
+        // Simulate a different lock ID on the instance (as if another host took the lock)
+        sagaStateRepo.LockAsync(instance, Arg.Any<CancellationToken>()).Returns("wrong-lock-id");
+        await instance.LockAsync(sagaStateRepo, CancellationToken.None);
+
+        // Release with mismatched lock ID should throw
+        await Assert.ThrowsAsync<LockException>(
+            () => repository.ReleaseAsync(instance, CancellationToken.None).AsTask());
+    }
+
+    [Fact]
+    public async Task LockAsync_should_throw_optimistic_lock_when_different_instance_same_descriptor_locked()
+    {
+        var repository = new InMemorySagaStateRepository();
+        var descriptor = SagaDescriptor.Create<FakeSaga>();
+        var correlationId = Guid.NewGuid().ToString();
+
+        var instance1 = new SagaInstance(
+            Guid.NewGuid().ToString(),
+            Guid.NewGuid().ToString(),
+            correlationId,
+            descriptor);
+
+        var instance2 = new SagaInstance(
+            Guid.NewGuid().ToString(),
+            Guid.NewGuid().ToString(),
+            correlationId,
+            descriptor);
+
+        await repository.LockAsync(instance1, CancellationToken.None);
+
+        await Assert.ThrowsAsync<OptimisticLockException>(
+            () => repository.LockAsync(instance2, CancellationToken.None).AsTask());
+    }
+
+    [Fact]
     public async Task ReleaseAsync_should_unlock_instance()
     {
         // Arrange

--- a/tests/OpenSleigh.Tests/SagaExecutionServiceTests.cs
+++ b/tests/OpenSleigh.Tests/SagaExecutionServiceTests.cs
@@ -102,6 +102,65 @@ public class SagaExecutionServiceTests
     }
 
     [Fact]
+    public async Task BeginProcessingAsync_should_return_noop_and_release_lock_when_CanProcess_false_after_lock()
+    {
+        var sagaStateRepository = Substitute.For<ISagaStateRepository>();
+        var outboxRepository = Substitute.For<IOutboxRepository>();
+        var sagaInstanceFactory = Substitute.For<ISagaInstanceFactory>();
+
+        var descriptor = SagaDescriptor.Create<FakeSaga>();
+        var messageContext = FakeMessageContext<FakeSagaStarter>.Create(new FakeSagaStarter());
+
+        var sagaInstance = new SagaInstance(
+            Guid.NewGuid().ToString(),
+            messageContext.MessageId,
+            messageContext.CorrelationId,
+            descriptor);
+
+        sagaStateRepository.FindAsync(descriptor, messageContext, Arg.Any<CancellationToken>())
+            .Returns(sagaInstance);
+
+        // First CanProcess call (before lock) returns true because message not processed.
+        // LockAsync succeeds, then we simulate the TOCTOU condition:
+        // another thread processed the message between initial check and lock, so
+        // mark the message as processed when LockAsync is called.
+        sagaStateRepository.LockAsync(sagaInstance, Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                sagaInstance.SetAsProcessed(messageContext);
+                return "lock-id";
+            });
+
+        var sut = new SagaExecutionService(sagaInstanceFactory, sagaStateRepository, outboxRepository);
+
+        var result = await sut.BeginProcessingAsync(messageContext, descriptor, CancellationToken.None);
+
+        Assert.IsType<NoOpSagaInstance>(result);
+        await sagaStateRepository.Received(1).ReleaseAsync(sagaInstance, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_should_delegate_to_repository()
+    {
+        var sagaStateRepository = Substitute.For<ISagaStateRepository>();
+        var outboxRepository = Substitute.For<IOutboxRepository>();
+        var sagaInstanceFactory = Substitute.For<ISagaInstanceFactory>();
+
+        var descriptor = SagaDescriptor.Create<FakeSaga>();
+        var sagaInstance = new SagaInstance(
+            Guid.NewGuid().ToString(),
+            Guid.NewGuid().ToString(),
+            Guid.NewGuid().ToString(),
+            descriptor);
+
+        var sut = new SagaExecutionService(sagaInstanceFactory, sagaStateRepository, outboxRepository);
+
+        await sut.ReleaseAsync(sagaInstance, CancellationToken.None);
+
+        await sagaStateRepository.Received(1).ReleaseAsync(sagaInstance, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task CommitAsync_should_append_outbox_and_release_lock()
     {
         // Arrange

--- a/tests/OpenSleigh.Tests/SagaInstanceTests.cs
+++ b/tests/OpenSleigh.Tests/SagaInstanceTests.cs
@@ -272,6 +272,78 @@ public class SagaInstanceTests
     }
 
     [Fact]
+    public async Task ProcessAsync_should_release_lock_and_rethrow_when_handler_throws()
+    {
+        var descriptor = SagaDescriptor.Create<FakeSaga>();
+        var messageContext = FakeMessageContext<FakeSagaStarter>.Create(new FakeSagaStarter());
+
+        var handler = Substitute.For<IMessageHandlerManager>();
+        var executionService = Substitute.For<ISagaExecutionService>();
+        var sagaStateRepo = Substitute.For<ISagaStateRepository>();
+
+        var sut = new SagaInstance("lorem", "ipsum", messageContext.CorrelationId, descriptor);
+
+        sagaStateRepo.LockAsync(sut, Arg.Any<CancellationToken>()).Returns("lock-123");
+        await sut.LockAsync(sagaStateRepo, CancellationToken.None);
+
+        handler.When(x => x.ProcessAsync(sut, messageContext, Arg.Any<CancellationToken>()))
+               .Do(_ => throw new InvalidOperationException("handler failed"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.ProcessAsync(handler, messageContext, executionService).AsTask());
+
+        await executionService.Received(1).ReleaseAsync(sut, CancellationToken.None);
+        Assert.Empty(sut.LockId);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_should_rethrow_original_exception_when_release_also_fails()
+    {
+        var descriptor = SagaDescriptor.Create<FakeSaga>();
+        var messageContext = FakeMessageContext<FakeSagaStarter>.Create(new FakeSagaStarter());
+
+        var handler = Substitute.For<IMessageHandlerManager>();
+        var executionService = Substitute.For<ISagaExecutionService>();
+        var sagaStateRepo = Substitute.For<ISagaStateRepository>();
+
+        var sut = new SagaInstance("lorem", "ipsum", messageContext.CorrelationId, descriptor);
+
+        sagaStateRepo.LockAsync(sut, Arg.Any<CancellationToken>()).Returns("lock-123");
+        await sut.LockAsync(sagaStateRepo, CancellationToken.None);
+
+        handler.When(x => x.ProcessAsync(sut, messageContext, Arg.Any<CancellationToken>()))
+               .Do(_ => throw new InvalidOperationException("handler failed"));
+        executionService.When(x => x.ReleaseAsync(sut, CancellationToken.None))
+                        .Do(_ => throw new Exception("release failed"));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.ProcessAsync(handler, messageContext, executionService).AsTask());
+
+        Assert.Equal("handler failed", ex.Message);
+        Assert.Empty(sut.LockId);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_should_not_call_release_when_lock_not_held()
+    {
+        var descriptor = SagaDescriptor.Create<FakeSaga>();
+        var messageContext = FakeMessageContext<FakeSagaStarter>.Create(new FakeSagaStarter());
+
+        var handler = Substitute.For<IMessageHandlerManager>();
+        var executionService = Substitute.For<ISagaExecutionService>();
+
+        var sut = new SagaInstance("lorem", "ipsum", messageContext.CorrelationId, descriptor);
+
+        handler.When(x => x.ProcessAsync(sut, messageContext, Arg.Any<CancellationToken>()))
+               .Do(_ => throw new InvalidOperationException("handler failed"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.ProcessAsync(handler, messageContext, executionService).AsTask());
+
+        await executionService.DidNotReceive().ReleaseAsync(Arg.Any<ISagaInstance>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public void Publish_throws_when_message_is_null()
     {
         var sut = new SagaInstance("lorem", "ipsum", "dolor", SagaDescriptor.Create<FakeSaga>());


### PR DESCRIPTION
## Summary

- **10 fixes** addressing E2E test flakiness caused by concurrency bugs in multi-host scenarios (multiple hosts sharing the same database and message transport)
- Root cause of the last 2 failures (`SqlRabbitParentChildScenario`): **saga lock race condition** — two hosts could both acquire the lock on the same saga instance because EF Core's `UPDATE` didn't include `LockId` in the `WHERE` clause
- All **39/39 E2E tests now pass** (verified across 3 consecutive runs)
- All **115 unit tests pass** unchanged

### Key fixes

| Fix | Description |
|-----|-------------|
| Lock release on failure | `SagaInstance.ProcessAsync` now releases the saga lock in a catch block when handler/commit fails |
| TOCTOU re-check | Re-check `CanProcess` after acquiring lock to close window between initial check and lock acquisition |
| Atomic in-memory locking | Replaced `ConcurrentDictionary.AddOrUpdate` with `lock` in `InMemorySagaStateRepository` |
| InMemory retry broadened | `InMemorySubscriber` retries on all exceptions, not just `LockException` |
| E2E test thread-safety | `ConcurrentBag` + `Interlocked`/`Volatile` in test callbacks |
| RabbitMQ DI ordering | `TryAddSingleton` for `QueueReferencesCreator` so test registrations aren't overwritten |
| RabbitMQ topology key | Cache key includes both exchange and queue name (was exchange-only, skipping queue creation) |
| PostgreSQL duplicate key detector | Broadened EF Core exception message matching |
| SQL saga lock race condition | `IsConcurrencyToken()` on `SagaState.LockId` + `DbUpdateConcurrencyException` → `LockException` |

### Breaking change

`ISagaExecutionService` has a new `ReleaseAsync` method — breaks external implementations of this interface.

## Test plan

- [x] Unit tests: 115/115 pass
- [x] InMemory E2E: 18/18 pass
- [x] SqlKafka E2E: 3/3 pass
- [x] SqlRabbit E2E: 18/18 pass (previously 16/18)
- [x] 3 consecutive full E2E runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)