### PR TITLE
feat: add .NET 10 support and update all NuGet packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,10 @@ jobs:
   build:
     resource_class: large
     environment:
-      TARGET_FRAMEWORK: net9.0
+      TARGET_FRAMEWORK: net10.0
 
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:9.0.203
+      - image: mcr.microsoft.com/dotnet/sdk:10.0.103
       - image: mongo:latest       
       - image: rabbitmq:3-management-alpine
         environment:
@@ -66,9 +66,9 @@ jobs:
   codecov:
     resource_class: large
     environment:
-      TARGET_FRAMEWORK: net9.0
+      TARGET_FRAMEWORK: net10.0
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:9.0.203
+      - image: mcr.microsoft.com/dotnet/sdk:10.0.103
       - image: 'mongo:latest'
       - image: 'rabbitmq:3-management-alpine'
         environment:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,17 +45,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '7.0'
-        include-prerelease: True
+        dotnet-version: '10.0.x'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -80,4 +79,4 @@ jobs:
         dotnet build -c Release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Setup .NET Core @ Latest
-        uses: actions/setup-dotnet@v1        
+        uses: actions/setup-dotnet@v4
         with:
-            dotnet-version: '9.0.x'
+            dotnet-version: '10.0.x'
 
       - name: Generate NuGet packages
         run: |

--- a/Versions.props
+++ b/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageVersion>3.0.6</PackageVersion>
     <CSharpLanguageVersion>12</CSharpLanguageVersion>
-	<TargetFrameworkVersion>net8.0;net9.0</TargetFrameworkVersion>
+	<TargetFrameworkVersion>net8.0;net9.0;net10.0</TargetFrameworkVersion>
     <RepositoryUrl>https://github.com/mizrael/OpenSleigh</RepositoryUrl>
     <PackageProjectUrl>https://opensleigh.gitbook.io/</PackageProjectUrl>
 </PropertyGroup>

--- a/benchmarks/OpenSleigh.Benchmarks/OpenSleigh.Benchmarks.csproj
+++ b/benchmarks/OpenSleigh.Benchmarks/OpenSleigh.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.Blazor/OpenSleigh.Samples.Blazor/OpenSleigh.Samples.Blazor.csproj
+++ b/samples/OpenSleigh.Samples.Blazor/OpenSleigh.Samples.Blazor/OpenSleigh.Samples.Blazor.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.API/OpenSleigh.Samples.ECommerce.API.csproj
+++ b/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.API/OpenSleigh.Samples.ECommerce.API.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'OpenSleigh.Samples.Sample2.API' " />
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.InventoryService/OpenSleigh.Samples.ECommerce.InventoryService.csproj
+++ b/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.InventoryService/OpenSleigh.Samples.ECommerce.InventoryService.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.NotificationsService/OpenSleigh.Samples.ECommerce.NotificationsService.csproj
+++ b/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.NotificationsService/OpenSleigh.Samples.ECommerce.NotificationsService.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.Orchestrator/OpenSleigh.Samples.ECommerce.Orchestrator.csproj
+++ b/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.Orchestrator/OpenSleigh.Samples.ECommerce.Orchestrator.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.PaymentService/OpenSleigh.Samples.ECommerce.PaymentService.csproj
+++ b/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.PaymentService/OpenSleigh.Samples.ECommerce.PaymentService.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.ShippingService/OpenSleigh.Samples.ECommerce.ShippingService.csproj
+++ b/samples/OpenSleigh.Samples.ECommerce/OpenSleigh.Samples.ECommerce.ShippingService/OpenSleigh.Samples.ECommerce.ShippingService.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.Sample1/OpenSleigh.Samples.Sample1.csproj
+++ b/samples/OpenSleigh.Samples.Sample1/OpenSleigh.Samples.Sample1.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.Sample2/OpenSleigh.Samples.Sample2.API/OpenSleigh.Samples.Sample2.API.csproj
+++ b/samples/OpenSleigh.Samples.Sample2/OpenSleigh.Samples.Sample2.API/OpenSleigh.Samples.Sample2.API.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/OpenSleigh.Samples.Sample2/OpenSleigh.Samples.Sample2.Worker/OpenSleigh.Samples.Sample2.Worker.csproj
+++ b/samples/OpenSleigh.Samples.Sample2/OpenSleigh.Samples.Sample2.Worker/OpenSleigh.Samples.Sample2.Worker.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenSleigh.InMemory/OpenSleigh.InMemory.csproj
+++ b/src/OpenSleigh.InMemory/OpenSleigh.InMemory.csproj
@@ -36,11 +36,11 @@
 		<InternalsVisibleTo Include="OpenSleigh.Tests" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
 </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Threading.Channels" Version="9.0.6" />
+    <PackageReference Include="System.Threading.Channels" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenSleigh.Persistence.Mongo/OpenSleigh.Persistence.Mongo.csproj
+++ b/src/OpenSleigh.Persistence.Mongo/OpenSleigh.Persistence.Mongo.csproj
@@ -29,8 +29,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Mongodb.Driver" Version="3.4.0" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+		<PackageReference Include="Mongodb.Driver" Version="3.6.0" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/OpenSleigh.Persistence.PostgreSQL/OpenSleigh.Persistence.PostgreSQL.csproj
+++ b/src/OpenSleigh.Persistence.PostgreSQL/OpenSleigh.Persistence.PostgreSQL.csproj
@@ -27,9 +27,13 @@
 		<PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/OpenSleigh.Persistence.SQL/OpenSleigh.Persistence.SQL.csproj
+++ b/src/OpenSleigh.Persistence.SQL/OpenSleigh.Persistence.SQL.csproj
@@ -28,8 +28,11 @@
 		<PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
     
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.6" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenSleigh.Persistence.SQLServer/OpenSleigh.Persistence.SQLServer.csproj
+++ b/src/OpenSleigh.Persistence.SQLServer/OpenSleigh.Persistence.SQLServer.csproj
@@ -27,9 +27,13 @@
 		<PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/OpenSleigh.Transport.Kafka/OpenSleigh.Transport.Kafka.csproj
+++ b/src/OpenSleigh.Transport.Kafka/OpenSleigh.Transport.Kafka.csproj
@@ -29,8 +29,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="2.10.1" />      
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="Confluent.Kafka" Version="2.13.0" />      
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/src/OpenSleigh.Transport.RabbitMQ/OpenSleigh.Transport.RabbitMQ.csproj
+++ b/src/OpenSleigh.Transport.RabbitMQ/OpenSleigh.Transport.RabbitMQ.csproj
@@ -29,9 +29,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="RabbitMQ.Client" Version="7.1.2" />
-		<PackageReference Include="Polly" Version="8.6.1" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+		<PackageReference Include="RabbitMQ.Client" Version="7.2.0" />
+		<PackageReference Include="Polly" Version="8.6.5" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/OpenSleigh/OpenSleigh.csproj
+++ b/src/OpenSleigh/OpenSleigh.csproj
@@ -34,13 +34,13 @@
 		</None>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
   </ItemGroup>
 
 </Project>

--- a/tests/OpenSleigh.E2ETests/OpenSleigh.E2ETests.csproj
+++ b/tests/OpenSleigh.E2ETests/OpenSleigh.E2ETests.csproj
@@ -10,13 +10,13 @@
 
   <ItemGroup>
 	  <PackageReference Include="Bogus" Version="35.6.5" />
-	  <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
-	  <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.6" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+	  <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+	  <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
 	  <PackageReference Include="NSubstitute" Version="5.3.0" />
-	  <PackageReference Include="System.Text.Json" Version="9.0.6" />
+	  <PackageReference Include="System.Text.Json" Version="10.0.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/OpenSleigh.Persistence.Mongo.Tests/OpenSleigh.Persistence.Mongo.Tests.csproj
+++ b/tests/OpenSleigh.Persistence.Mongo.Tests/OpenSleigh.Persistence.Mongo.Tests.csproj
@@ -8,13 +8,13 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.6" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/tests/OpenSleigh.Persistence.SQL.Tests/OpenSleigh.Persistence.SQL.Tests.csproj
+++ b/tests/OpenSleigh.Persistence.SQL.Tests/OpenSleigh.Persistence.SQL.Tests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
-	<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6" />
-	<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />    
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
+	<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
+	<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />    
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/OpenSleigh.Tests/OpenSleigh.Tests.csproj
+++ b/tests/OpenSleigh.Tests/OpenSleigh.Tests.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/OpenSleigh.Transport.Kafka.Tests/OpenSleigh.Transport.Kafka.Tests.csproj
+++ b/tests/OpenSleigh.Transport.Kafka.Tests/OpenSleigh.Transport.Kafka.Tests.csproj
@@ -6,15 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/OpenSleigh.Transport.RabbitMQ.Tests/OpenSleigh.Transport.RabbitMQ.Tests.csproj
+++ b/tests/OpenSleigh.Transport.RabbitMQ.Tests/OpenSleigh.Transport.RabbitMQ.Tests.csproj
@@ -6,15 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

- **Add net10.0 target framework** alongside existing net8.0 and net9.0 via centralized `Versions.props` (propagates to all 26 projects)
- **Update all NuGet packages** to latest compatible versions
- **Modernize CI/CD pipelines** with updated SDK images and GitHub Actions versions

## Notable Details

- **EF Core 10.x is net10.0-only** — conditional `ItemGroup` references used in Persistence.SQL, SQLServer, and PostgreSQL projects (EF Core 9.x for net8.0/net9.0, 10.x for net10.0)
- **Swashbuckle kept at 9.0.6** — version 10.x has breaking API changes (OpenAPI v2 migration), not worth updating sample code
- **All `#if NET9_0_OR_GREATER` conditionals** automatically apply to .NET 10, no code changes needed

## Package Updates

| Category | Packages | Version Change |
|----------|----------|---------------|
| Microsoft.Extensions.* | DI, Hosting, Logging, Configuration, etc. | 9.0.x → 10.0.3 |
| Entity Framework Core | EFCore, EFCore.Relational, SqlServer, Npgsql | 9.0.x → 10.0.x (net10.0 only) |
| Microsoft.SourceLink.GitHub | SourceLink | 8.0.0 → 10.0.103 |
| Test infrastructure | Microsoft.NET.Test.Sdk, xunit.runner.visualstudio | 17.14.1 → 18.0.1, 3.1.1 → 3.1.5 |
| RabbitMQ | RabbitMQ.Client, Polly | 7.1.2 → 7.2.0, 8.6.1 → 8.6.5 |
| MongoDB | MongoDB.Driver | 3.4.0 → 3.6.0 |
| Kafka | Confluent.Kafka | 2.10.1 → 2.13.0 |
| Benchmarks | BenchmarkDotNet | 0.14.0 → 0.15.8 |
| CI/CD | CircleCI SDK, GitHub Actions | Pinned 10.0.103, actions@v4/v3 |

## Test plan

- [x] `dotnet restore` succeeds for all three frameworks
- [x] `dotnet build -c Release` — 0 errors
- [x] Unit tests pass on net8.0 (248 passed)
- [x] Unit tests pass on net9.0 (248 passed)
- [x] Unit tests pass on net10.0 (248 passed)
- [ ] Integration tests with Docker infrastructure
- [ ] Verify VS Test Explorer discovers net10.0 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)